### PR TITLE
Add optional BASIC_AUTH_USERS env var for password-based login

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ services:
   - `WEB_SESSION_PATH`: Path to the session storage directory (defaults to `<DB_PATH directory>/sessions`).
   - `WEB_BASE_URL`: The public URL of the web server (e.g. `https://gate.example.com` or `http://localhost:3000`).
   - `GOOGLE_ADMIN_EMAILS`: A comma-separated list of email addresses that have admin access on the web UI.
+  - `BASIC_AUTH_USERS`: Optional. A semicolon-separated list of username,password,isAdmin tuples for password-based login (e.g. `admin,secret,true;user,pass,false`). **Not recommended for production** — intended for testing and local development only.
 
 4. Run the bot:
    ```sh

--- a/src/framework/environment.ts
+++ b/src/framework/environment.ts
@@ -15,6 +15,36 @@ export const unit = env.get('UNIT').asString();
 export const propertyNotes = env.get('PROPERTY_NOTES').asString();
 export const buildVersion = env.get('BUILD_VERSION').default('0.0.0').asString();
 
+export interface BasicAuthUser {
+  username: string;
+  password: string;
+  isAdmin: boolean;
+}
+
+const parseBasicAuthUsers = (): BasicAuthUser[] => {
+  const raw = env.get('BASIC_AUTH_USERS').asString();
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(';')
+    .map((entry) => {
+      const [username, password, isAdminStr, ...rest] = entry.split(',');
+
+      if (!username || !password || !isAdminStr || rest.length > 0) {
+        return null;
+      }
+
+      const isAdmin = isAdminStr.toLowerCase() === 'true';
+
+      return { username, password, isAdmin };
+    })
+    .filter((user) => user !== null);
+};
+
+export const basicAuthUsers = parseBasicAuthUsers();
+
 export interface WebConfig {
   googleClientId: string;
   googleClientSecret: string;

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -56,21 +56,21 @@ export const removePendingRequest = async (id: string) => {
 
 export const getPendingRequests = () => [...(db.data.pendingRequests ?? [])];
 
-export const addWebUser = async (googleId: string, info: { email: string; name: string }) => {
+export const addWebUser = async (userId: string, info: { email: string; name: string }) => {
   if (!db.data.webUsers) {
     db.data.webUsers = {};
   }
-  db.data.webUsers[googleId] = { googleId, ...info, allowed: true };
+  db.data.webUsers[userId] = { googleId: userId, ...info, allowed: true };
   await db.write();
 };
 
-export const isWebUserAllowed = (googleId: string) => db.data.webUsers?.[googleId]?.allowed ?? false;
+export const isWebUserAllowed = (userId: string) => db.data.webUsers?.[userId]?.allowed ?? false;
 
 export const getWebUsers = () => Object.values(db.data.webUsers ?? {}).filter((u) => u.allowed);
 
-export const removeWebUser = async (googleId: string) => {
+export const removeWebUser = async (userId: string) => {
   if (db.data.webUsers) {
-    delete db.data.webUsers[googleId];
+    delete db.data.webUsers[userId];
   }
   await db.write();
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,8 @@ export interface UserInfo {
 }
 
 export interface WebSessionUser {
-  googleId: string;
+  provider: 'google' | 'password';
+  id: string;
   email: string;
   name: string;
   isAdmin: boolean;

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'node:path';
 import express from 'express';
 import session from 'express-session';
 import sessionFileStore from 'session-file-store';
-import { webConfig } from '../framework/environment.js';
+import { webConfig, basicAuthUsers } from '../framework/environment.js';
 import { authRouter } from './routes/auth.js';
 import { dashboardRouter } from './routes/dashboard.js';
 import { adminRouter } from './routes/admin.js';
@@ -84,7 +84,9 @@ export const startWebServer = () => {
       return;
     }
 
-    res.render('login');
+    const error = req.query.error as string | undefined;
+
+    res.render('login', { showPasswordLogin: basicAuthUsers.length > 0, error });
   });
 
   app.listen(webPort, () => {

--- a/src/web/locales/en.json
+++ b/src/web/locales/en.json
@@ -7,7 +7,12 @@
   "login": {
     "title": "Gate Bot",
     "subtitle": "Sign in to open the gate or manage access.",
-    "signIn": "Sign in with Google"
+    "signIn": "Sign in with Google",
+    "signInPassword": "Sign In",
+    "username": "Username",
+    "password": "Password",
+    "invalidCredentials": "Invalid username or password.",
+    "missingCredentials": "Please enter username and password."
   },
   "dashboard": {
     "title": "Dashboard",

--- a/src/web/locales/he.json
+++ b/src/web/locales/he.json
@@ -7,7 +7,12 @@
   "login": {
     "title": "Gate Bot",
     "subtitle": "התחבר כדי לפתוח את השער או לנהל גישה.",
-    "signIn": "התחבר באמצעות Google"
+    "signIn": "התחבר באמצעות Google",
+    "signInPassword": "התחבר",
+    "username": "שם משתמש",
+    "password": "סיסמה",
+    "invalidCredentials": "שם משתמש או סיסמה שגויים.",
+    "missingCredentials": "נא להזין שם משתמש וסיסמה."
   },
   "dashboard": {
     "title": "לוח בקרה",

--- a/src/web/locales/ru.json
+++ b/src/web/locales/ru.json
@@ -7,7 +7,12 @@
   "login": {
     "title": "Gate Bot",
     "subtitle": "Войдите, чтобы открыть ворота или управлять доступом.",
-    "signIn": "Войти через Google"
+    "signIn": "Войти через Google",
+    "signInPassword": "Войти",
+    "username": "Имя пользователя",
+    "password": "Пароль",
+    "invalidCredentials": "Неверное имя пользователя или пароль.",
+    "missingCredentials": "Пожалуйста, введите имя пользователя и пароль."
   },
   "dashboard": {
     "title": "Панель",

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from 'express';
 
 declare module 'express-session' {
   interface SessionData {
-    user?: { googleId: string; email: string; name: string; isAdmin: boolean };
+    user?: { provider: 'google' | 'password'; id: string; email: string; name: string; isAdmin: boolean };
     oauthState?: string;
     locale?: string;
   }

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { Router } from 'express';
-import { webConfig as rawWebConfig } from '../../framework/environment.js';
+import { webConfig as rawWebConfig, basicAuthUsers } from '../../framework/environment.js';
 
 const webConfig = rawWebConfig!;
 const { googleClientId, googleClientSecret, webBaseUrl, googleAdminEmails } = webConfig;
@@ -73,7 +73,8 @@ router.get('/google/callback', async (req, res): Promise<void> => {
 
   const userInfo = (await userResponse.json()) as { id: string; email: string; name: string };
   const user = {
-    googleId: userInfo.id,
+    provider: 'google' as const,
+    id: userInfo.id,
     email: userInfo.email,
     name: userInfo.name,
     isAdmin: googleAdminEmails.has(userInfo.email),
@@ -81,6 +82,37 @@ router.get('/google/callback', async (req, res): Promise<void> => {
 
   // eslint-disable-next-line require-atomic-updates
   req.session.user = user;
+
+  res.redirect('/dashboard');
+});
+
+router.post('/password', (req, res): void => {
+  if (basicAuthUsers.length === 0) {
+    res.status(404).send('Not found');
+    return;
+  }
+
+  const { username, password } = req.body as { username?: string; password?: string };
+
+  if (!username || !password) {
+    res.redirect('/?error=missing');
+    return;
+  }
+
+  const match = basicAuthUsers.find((u) => u.username === username && u.password === password);
+
+  if (!match) {
+    res.redirect('/?error=invalid');
+    return;
+  }
+
+  req.session.user = {
+    provider: 'password',
+    id: username,
+    email: '',
+    name: username,
+    isAdmin: match.isAdmin,
+  };
 
   res.redirect('/dashboard');
 });

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -33,14 +33,14 @@ const buildPropertyInfo = (allowed: boolean) => ({
 
 router.get('/status', (req, res): void => {
   const user = req.session.user!;
-  const allowed = user.isAdmin || isWebUserAllowed(user.googleId);
+  const allowed = user.isAdmin || isWebUserAllowed(user.id);
 
   res.json({ allowed });
 });
 
 router.get('/', (req, res): void => {
   const user = req.session.user!;
-  const allowed = user.isAdmin || isWebUserAllowed(user.googleId);
+  const allowed = user.isAdmin || isWebUserAllowed(user.id);
 
   res.render('dashboard', {
     user,
@@ -52,7 +52,7 @@ router.get('/', (req, res): void => {
 
 router.post('/open', async (req, res): Promise<void> => {
   const user = req.session.user!;
-  const allowed = user.isAdmin || isWebUserAllowed(user.googleId);
+  const allowed = user.isAdmin || isWebUserAllowed(user.id);
 
   if (!allowed) {
     res.render('dashboard', { user, isAllowed: false, ...buildPropertyInfo(false), message: 'Not authorized' });
@@ -61,8 +61,8 @@ router.post('/open', async (req, res): Promise<void> => {
 
   try {
     await open({
-      userId: user.googleId,
-      username: user.email,
+      userId: user.id,
+      username: user.email || user.name,
       firstName: user.name,
       sourceType: 'web',
     });
@@ -81,27 +81,27 @@ router.post('/open', async (req, res): Promise<void> => {
 router.post('/request-access', async (req, res): Promise<void> => {
   const user = req.session.user!;
 
-  if (user.isAdmin || isWebUserAllowed(user.googleId)) {
+  if (user.isAdmin || isWebUserAllowed(user.id)) {
     res.render('dashboard', { user, isAllowed: true, ...buildPropertyInfo(true), message: alreadyAllowed });
     return;
   }
 
   await addPendingRequest({
-    id: `web:${user.googleId}`,
+    id: `web:${user.id}`,
     sourceType: 'web',
-    sourceUserId: user.googleId,
+    sourceUserId: user.id,
     name: user.name,
     email: user.email,
     requestedAt: new Date().toISOString(),
   });
 
   await pMap(adminUserIds, (adminId) => {
-    sendTelegram(adminId, `Web access request\nName: ${user.name}\nEmail: ${user.email}\nGoogle ID: ${user.googleId}`, [
+    sendTelegram(adminId, `Web access request\nName: ${user.name}\nEmail: ${user.email}\nUser ID: ${user.id}`, [
       [
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        { text: 'Allow✅', callback_data: `allow_${user.googleId}` },
+        { text: 'Allow✅', callback_data: `allow_${user.id}` },
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        { text: 'Deny⛔', callback_data: `deny_${user.googleId}` },
+        { text: 'Deny⛔', callback_data: `deny_${user.id}` },
       ],
     ]);
   });

--- a/src/web/views/login.ejs
+++ b/src/web/views/login.ejs
@@ -2,6 +2,25 @@
   <div class="card" style="text-align: center; padding: 3rem 1.5rem;">
     <h1 style="font-size: 1.5rem; margin-bottom: 0.5rem;"><%= t('login.title') %></h1>
     <p style="margin-bottom: 1.5rem;"><%= t('login.subtitle') %></p>
+
+    <% if (typeof showPasswordLogin !== 'undefined' && showPasswordLogin) { %>
+      <% if (typeof error !== 'undefined' && error === 'invalid') { %>
+        <div class="message message-error"><%= t('login.invalidCredentials') %></div>
+      <% } else if (typeof error !== 'undefined' && error === 'missing') { %>
+        <div class="message message-error"><%= t('login.missingCredentials') %></div>
+      <% } %>
+      <form method="post" action="/auth/password" style="margin-bottom: 1.5rem;">
+        <div style="margin-bottom: 0.75rem;">
+          <input type="text" name="username" placeholder="<%= t('login.username') %>" required style="width: 100%; padding: 0.6rem 0.8rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); font-size: 0.9rem;">
+        </div>
+        <div style="margin-bottom: 0.75rem;">
+          <input type="password" name="password" placeholder="<%= t('login.password') %>" required style="width: 100%; padding: 0.6rem 0.8rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); font-size: 0.9rem;">
+        </div>
+        <button type="submit" class="btn" style="width: 100%; justify-content: center;"><%= t('login.signInPassword') %></button>
+      </form>
+      <div style="border-top: 1px solid var(--border); margin: 1.5rem 0;"></div>
+    <% } %>
+
     <a href="/auth/google" class="btn btn-google">
       <svg width="18" height="18" viewBox="0 0 48 48"><path fill="#4285F4" d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"/><path fill="#34A853" d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"/><path fill="#FBBC05" d="M11.69 28.18C11.25 26.86 11 25.45 11 24s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24c0 3.55.85 6.91 2.34 9.88l7.35-5.7z"/><path fill="#EA4335" d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"/></svg>
       <%= t('login.signIn') %>


### PR DESCRIPTION
Adds support for username/password login via the `BASIC_AUTH_USERS` environment variable.

Format: `username1,password1,true;username2,password2,false`

- If the env var is not set, the password login form is hidden and `POST /auth/password` returns 404
- Session user is now provider-agnostic with `provider`, `id`, `email`, `name`, `isAdmin` fields
- Updated locale files with translations for en, he, ru
- README documents the new option with a note that it's not recommended for production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional password-based sign-in alongside Google login.
  * Login screens now show password login fields and clear error messages for missing or invalid credentials.
  * Support was added for configuring local/testing users through an environment variable.

* **Bug Fixes**
  * Updated session and access handling to use a more consistent user identity across login methods.
  * Dashboard access and access-request flows now work with both login types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->